### PR TITLE
Fix: Correct subforum selection logic in new post page

### DIFF
--- a/components/post/category-selector.tsx
+++ b/components/post/category-selector.tsx
@@ -160,43 +160,44 @@ export function CategorySelector({
                       <div className="flex border-t border-slate-600">
                         <button
                           type="button"
-                          onClick={() => handleForumSelect(forum.id, category.id)}
+                          onClick={() => {
+                            if (hasSubforums) {
+                              toggleForum(forum.id)
+                            } else {
+                              handleForumSelect(forum.id, category.id)
+                            }
+                          }}
                           className={`
-                            flex-1 p-3 text-left flex items-center gap-3
-                            hover:bg-slate-700/30 transition-colors
-                            ${selectedForum === forum.id ? 'bg-retro-blue/10 text-retro-neon' : 'text-retro-text'}
+                            w-full p-3 text-left flex items-center justify-between gap-3
+                            transition-colors
+                            ${!hasSubforums ? 'hover:bg-slate-700/30' : ''}
+                            ${selectedForum === forum.id && !hasSubforums ? 'bg-retro-blue/10 text-retro-neon' : 'text-retro-text'}
                           `}
                         >
-                          <div className="w-5 h-5 bg-gradient-to-br from-slate-600 to-slate-700 rounded flex items-center justify-center ml-4">
-                            {hasSubforums ? (
-                              <FolderOpen className="w-3 h-3 text-slate-300" />
-                            ) : (
-                              <Folder className="w-3 h-3 text-slate-300" />
-                            )}
-                          </div>
-                          <div className="flex-1">
-                            <div className="font-medium flex items-center gap-2">
-                              {forum.name}
-                              {selectedForum === forum.id && (
-                                <Check className="w-4 h-4 text-retro-neon" />
+                          <div className="flex items-center gap-3 flex-1">
+                            <div className="w-5 h-5 bg-gradient-to-br from-slate-600 to-slate-700 rounded flex items-center justify-center ml-4">
+                              {hasSubforums ? (
+                                isForumExpanded ? <FolderOpen className="w-3 h-3 text-slate-300" /> : <Folder className="w-3 h-3 text-slate-300" />
+                              ) : (
+                                <Folder className="w-3 h-3 text-slate-300" />
                               )}
                             </div>
-                            {forum.description && (
-                              <div className="text-xs text-slate-400 mt-1">{forum.description}</div>
-                            )}
+                            <div className="flex-1">
+                              <div className="font-medium flex items-center gap-2">
+                                {forum.name}
+                                {selectedForum === forum.id && !hasSubforums && (
+                                  <Check className="w-4 h-4 text-retro-neon" />
+                                )}
+                              </div>
+                              {forum.description && (
+                                <div className="text-xs text-slate-400 mt-1">{forum.description}</div>
+                              )}
+                            </div>
                           </div>
-                        </button>
-
-                        {/* Toggle Subforum Button */}
-                        {hasSubforums && (
-                          <button
-                            type="button"
-                            onClick={() => toggleForum(forum.id)}
-                            className="p-3 border-t border-slate-600 hover:bg-slate-700/30 transition-colors"
-                          >
+                          {hasSubforums && (
                             <ChevronRight className={`w-4 h-4 text-slate-400 transition-transform ${isForumExpanded ? 'rotate-90' : ''}`} />
-                          </button>
-                        )}
+                          )}
+                        </button>
                       </div>
 
                       {/* Subforums */}


### PR DESCRIPTION
Previously, when creating a new post, you could incorrectly select a parent forum even if it contained subforums. The expected behavior is that if a forum has subforums, the parent forum itself should not be selectable for posting; instead, you should be guided to select one of its subforums.

This commit addresses the issue by modifying the `CategorySelector` component:

1.  Parent forums with subforums are no longer directly selectable. Clicking on them now solely toggles the visibility of their subforums.
2.  The `handleForumSelect` callback is only triggered for forums without subforums or for the subforums themselves.
3.  UI adjustments have been made to visually differentiate non-selectable parent forums:
    - Hover effects (background change) are removed from parent forums that act as toggles, making selectable forums more distinct.
    - Folder icons now dynamically update to `FolderOpen` when a parent forum's subforums are expanded.

These changes ensure that you can only post in leaf-node forums (forums without subforums or the subforums themselves), aligning the behavior of the new post page with the intended forum structure.